### PR TITLE
docs: add bilingual guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,36 @@
 
 [![Release](https://github.com/soulteary/docker-quick-docs/actions/workflows/release.yaml/badge.svg)](https://github.com/soulteary/docker-quick-docs/actions/workflows/release.yaml) [![Codecov](https://github.com/soulteary/docker-quick-docs/actions/workflows/codecov.yml/badge.svg)](https://github.com/soulteary/docker-quick-docs/actions/workflows/codecov.yml) [![CodeQL](https://github.com/soulteary/docker-quick-docs/actions/workflows/codeql.yml/badge.svg)](https://github.com/soulteary/docker-quick-docs/actions/workflows/codeql.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/soulteary/docker-quick-docs)](https://goreportcard.com/report/github.com/soulteary/docker-quick-docs)
 
-本地部署、能够快速访问的文档工具，用来改善 GitHub Pages 文档访问体验。
+本地部署、能够快速访问的文档工具，用来改善 GitHub Pages 文档访问体验。The project offers a lightweight way to host documentation locally and browse it at high speed without depending on GitHub Pages.
 
-## 下载工具
+## Overview | 项目简介
 
-在 GitHub [发布页面](https://github.com/soulteary/docker-quick-docs/releases) 下载适合你操作系统的可执行文件。
+- **EN**: Docker Quick Docs serves static documentation bundles from your local machine, removing latency introduced by public hosting and giving you full control of the browsing experience.
+- **ZH**: Docker Quick Docs 可以在本地机器中快速部署静态文档，绕过公网访问的延迟，让你完全掌控浏览体验。
+
+## Download | 获取方式
+
+- **EN**: Download the executable that matches your operating system from the GitHub [Releases page](https://github.com/soulteary/docker-quick-docs/releases).
+- **ZH**: 前往 GitHub [发布页面](https://github.com/soulteary/docker-quick-docs/releases) 下载与你操作系统匹配的可执行文件。
 
 ![](.github/assets.jpg)
 
-或者使用 Docker 下载工具：
+- **EN**: Prefer Docker? Pull the ready-to-run image from Docker Hub.
+- **ZH**: 如果习惯使用 Docker，可以直接从 Docker Hub 拉取镜像。
 
 ![](.github/dockerhub.jpg)
 
 ```bash
 docker pull soulteary/docker-quick-docs:v0.1.7
-# 或者
+# EN: or pull the latest tag automatically
+# ZH: 或者直接拉取最新的镜像标签
 docker pull soulteary/docker-quick-docs
 ```
 
-## 使用工具
+## Usage | 使用示例
 
-以 [baidu/san](http://github.com/baidu/san) 为例，我们将这个软件的 GitHub 进行本地化部署。
-
-首先，获取想本地部署的软件的文档代码，GitHub Pages，通常需要下载 GitHub 的 `gh-pages` 分支：
+- **EN**: The following walkthrough localizes the documentation of [baidu/san](http://github.com/baidu/san) by cloning its GitHub Pages branch.
+- **ZH**: 下面演示如何克隆 [baidu/san](http://github.com/baidu/san) 的 GitHub Pages 分支，将文档本地化部署。
 
 ```bash
 git clone http://github.com/baidu/san --depth 1 --branch=gh-pages
@@ -38,39 +45,45 @@ Receiving objects: 100% (405/405), 2.17 MiB | 5.18 MiB/s, done.
 Resolving deltas: 100% (154/154), done.
 ```
 
-然后，我们可以将这些文档放到 `docs` 目录中。
+- **EN**: Move the cloned site into the `docs` directory so the server can pick it up.
+- **ZH**: 将克隆好的站点移动到 `docs` 目录中，便于程序读取。
 
 ```bash
 mv san docs/
 ```
 
-然后我们执行程序即可：
+- **EN**: Start the server with either the native binary or the Docker container.
+- **ZH**: 使用原生二进制或 Docker 容器启动服务。
 
 ```bash
-# 如果你选择使用可执行文件
+# EN: native binary
+# ZH: 原生二进制
 ./quick-docs
 
-# 如果你选择使用 docker
+# EN: Docker container
+# ZH: Docker 容器
 docker run --rm -it -v `pwd`/docs:/app/docs -p 8080:8080 soulteary/docker-quick-docs:v0.1.7
 ```
 
-程序执行完毕，我们将看到类似下面的日志：
+- **EN**: When the application starts you should see logs similar to the following.
+- **ZH**: 程序启动后，会出现类似如下的日志输出。
 
 ```bash
 2024/01/04 10:38:31 Quick Docs
 2024/01/04 10:38:31 未设置环境变量 `PORT`，使用默认端口：8080
 ```
 
-此时访问浏览器，就能够快速的访问文档啦。
+- **EN**: Open your browser at `http://localhost:8080` to browse the imported documentation immediately.
+- **ZH**: 打开浏览器访问 `http://localhost:8080`，即可快速浏览刚导入的文档。
 
-## 配置
+## Configuration | 配置
 
-如果你想调整端口，可以设置 `PORT` 环境变量。
-
-例如：
+- **EN**: Customize the listening port by defining the `PORT` environment variable before starting the program.
+- **ZH**: 如果需要修改监听端口，在启动程序前设置 `PORT` 环境变量即可。
 
 ```bash
 PORT=8080 ./quick-docs
-# 或
+# EN: or with Docker
+# ZH: 或者使用 Docker
 docker run --rm -it -e PORT=8080 -v `pwd`/docs:/app/docs -p 8080:8080 soulteary/docker-quick-docs:v0.1.7
 ```


### PR DESCRIPTION
## Summary
- add bilingual overview and download guidance to the README
- expand usage and configuration instructions with paired English and Chinese notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cd5db86588327a82cf71232529671

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds bilingual EN/ZH guidance to README, restructuring sections and expanding usage/config with Docker examples.
> 
> - **Documentation (`README.md`)**:
>   - **Bilingual content**: Add paired EN/ZH descriptions across sections.
>   - **Structure**: Introduce `Overview`, `Download`, `Usage`, and `Configuration` sections.
>   - **Download**:
>     - Add Docker Hub pull instructions, including latest-tag note.
>   - **Usage**:
>     - Steps to clone `gh-pages`, move content into `docs`, and run via native binary or Docker.
>     - Include sample startup logs and note to visit `http://localhost:8080`.
>   - **Configuration**:
>     - Document `PORT` env var usage with both native and Docker examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39b584535813ed33fef71c731a0cf9faf301af23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->